### PR TITLE
Fix strip_trailing_zeros returning empty string for zero values

### DIFF
--- a/freqtrade/util/formatters.py
+++ b/freqtrade/util/formatters.py
@@ -18,7 +18,10 @@ def strip_trailing_zeros(value: str) -> str:
     :param value: Value to be stripped
     :return: Stripped value
     """
-    return value.rstrip("0").rstrip(".")
+    result = value.rstrip("0").rstrip(".")
+    if result in ("", "-"):
+        return "0"
+    return result
 
 
 def round_value(value: float, decimals: int, keep_trailing_zeros=False) -> str:

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -1,0 +1,14 @@
+import pytest
+
+from freqtrade.util.formatters import strip_trailing_zeros
+
+
+def test_strip_trailing_zeros_basic():
+    assert strip_trailing_zeros("1.2300") == "1.23"
+    assert strip_trailing_zeros("1.000") == "1"
+
+
+def test_strip_trailing_zeros_zero_value():
+    assert strip_trailing_zeros("0.000") == "0"
+    assert strip_trailing_zeros("0") == "0"
+    assert strip_trailing_zeros("-0.000") == "0"


### PR DESCRIPTION
## Summary
- handle empty results in strip_trailing_zeros so zero values return "0"
- add tests for strip_trailing_zeros covering zero and non-zero values

## Testing
- `pytest tests/test_formatters.py` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68971371aa5083239b87d99f250a6fbf